### PR TITLE
Fix Python 3 compatibility, drop Python 2 support

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,6 +5,5 @@
     
     @author: Dr Mike Brooks
 """
-from __future__ import unicode_literals
 
 from ledstrip import LEDStrip

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,6 @@
 """
 Raspiled - Config
 """
-from __future__ import unicode_literals
 import configparser
 import logging
 import os
@@ -13,13 +12,13 @@ logging.basicConfig(format='[%(asctime)s RASPILED] %(message)s',
 
 def ordereddict_to_int(ordered_dict):
     """
-    Converts an OrderedDict with unicode values to integers and/or floats (port and pins).
+    Converts an OrderedDict with str values to integers and/or floats (port and pins).
     @param ordered_dict: <OrderedDict> containg RASPILED configuration.
 
-    @returns: <OrderedDict> with integers instead of unicode values.
+    @returns: <OrderedDict> with integers instead of str values.
     """
     for key,value in ordered_dict.items():
-        if u"." in unicode(value):
+        if "." in value:
             casting_function = float
         else:
             casting_function = int

--- a/src/ledstrip.py
+++ b/src/ledstrip.py
@@ -10,7 +10,6 @@
 
     @author: Dr Mike Brooks
 """
-from __future__ import unicode_literals
 
 from named_colours import NAMED_COLOURS
 
@@ -26,8 +25,8 @@ import threading
 from six.moves.html_parser import HTMLParser
 
 
-logging.basicConfig(format=b'[%(asctime)s RASPILED] %(message)s',
-                    datefmt=b'%H:%M:%S', level=logging.INFO)
+logging.basicConfig(format='[%(asctime)s RASPILED] %(message)s',
+                    datefmt='%H:%M:%S', level=logging.INFO)
 
 
 ##### Constants #####
@@ -58,14 +57,13 @@ def pigpiod_process():
     process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
     output, error = process.communicate()
 
-    if output == '':
+    if output == b'':
         logging.warn('*** [STARTING PIGPIOD] i.e. "sudo pigpiod" ***')
         cmd = 'sudo pigpiod'
         process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
         output, error = process.communicate()
     else:
-        logging.info('PIGPIOD is running! PID: %s' % output.split('\n')[0])
-
+        logging.info('PIGPIOD is running! PID: %s', output.split(b'\n')[0])
 
 pigpiod_process()
 
@@ -81,7 +79,7 @@ class PiPinInterface(pigpio.pi, object):
     def __init__(self, params):
         super(PiPinInterface, self).__init__(params['pi_host'], params['pig_port'])
 
-    def __unicode__(self):
+    def __str__(self):
         """
         Says who I am!
         """
@@ -91,7 +89,7 @@ class PiPinInterface(pigpio.pi, object):
         return "RaspberryPi Pins @ {ipv4}:{port}... {status}".format(ipv4=self._host, port=self._port, status=status)
 
     def __repr__(self):
-        return str(self.__unicode__())
+        return str(self)
 
 
 class LEDStrip(object):
@@ -297,15 +295,15 @@ class LEDStrip(object):
         concatenate a mixture of comma strings and items
         """
         colours = copy.deepcopy(colours)  # Ensure we don't bugger up original
-        if isinstance(colours, (str, unicode)):
+        if not isinstance(colours, list):
             colours = [colours]  # Listify
         colours.extend(args)
         intermediate_list = []
         # Add in comma delimited stuff
         h = HTMLParser()
         for colour_term in colours:
-            if isinstance(colour_term, (str, unicode)):
-                colour_term_decoded = h.unescape(colour_term)  # HTML char decode
+            if isinstance(colour_term, str):
+                colour_term_decoded = colour_term
                 colour_terms_list = colour_term_decoded.split(",")
                 intermediate_list.extend(colour_terms_list)
             else:
@@ -313,7 +311,7 @@ class LEDStrip(object):
         # Now sanitise the list again
         output_list = []
         for colour in intermediate_list:
-            if isinstance(colour, (str, unicode)):
+            if isinstance(colour, str):
                 colour_clean = colour.strip()
             output_list.append(colour)
         return output_list
@@ -348,10 +346,8 @@ class LEDStrip(object):
 
         return out_milliseconds
 
-    def __unicode__(self):
-        """
-        Print current colours as unicode
-        """
+    def __str__(self):
+        """Current colours as str"""
         return "{},{},{}".format(*self.rgb)
 
     def sync_channels(self):
@@ -540,7 +536,7 @@ class LEDStrip(object):
         gap_b = b - init_b
         n_steps = int(float(fade) / 20.0)  # 50Hz = 20 milliseconds
 
-        for step in xrange(0, n_steps):
+        for step in range(0, n_steps):
             fractional_progress = float(step) / n_steps
             cur_r = init_r + (gap_r * fractional_progress)
             cur_g = init_g + (gap_g * fractional_progress)
@@ -678,7 +674,7 @@ class LEDStrip(object):
         Minimum units of 10ms
         """
         ten_ms_steps = int(round(seconds * 100))
-        for _i in xrange(0, ten_ms_steps):
+        for _i in range(0, ten_ms_steps):
             if self._sequence_stop_signal:
                 break
             sleep(0.01)
@@ -790,8 +786,8 @@ class LEDStrip(object):
 
         @keyword seconds: <float> Number of seconds to do the sequence over
         @keyword milliseconds: <float> Number of milliseconds to do the sequence over, gets added to seconds if both provided
-        @keyword temp_start: <unicode> A colour temperature (in Kelvin) to start the sequence from
-        @keyword temp_end: <unicode> A colour temperature (in Kelvin) to end the sequence at
+        @keyword temp_start: <str> A colour temperature (in Kelvin) to start the sequence from
+        @keyword temp_end: <str> A colour temperature (in Kelvin) to end the sequence at
         @keyword fade: <Boolean> whether to fade between steps (True) or jump (False)
         """
 
@@ -847,7 +843,7 @@ class LEDStrip(object):
         # And run the loop
         t1 = time.time()
         check = True  # We only check the current values on the first run
-        for temp in xrange(temp_0, temp_n, temp_step):
+        for temp in range(temp_0, temp_n, temp_step):
             if self._sequence_stop_signal:  # Bail if sequence should stop
                 return None
             k = u"%sk" % temp

--- a/src/named_colours.py
+++ b/src/named_colours.py
@@ -5,7 +5,6 @@
     
     Named colours (CSS4 set)
 """
-from __future__ import unicode_literals
 
 CSS4_COLOURS = {
     'indigo': '#4B0082',

--- a/src/raspiled_listener.py
+++ b/src/raspiled_listener.py
@@ -9,7 +9,6 @@
     
         @requires: twisted
 """
-from __future__ import unicode_literals
 import os
 import sys
 # Add some gymnastics so we can use imports relative to the parent dir.
@@ -38,7 +37,6 @@ RASPILED_DIR = os.path.dirname(os.path.realpath(__file__))  # The directory we'r
 RESOLVED_USER_SETTINGS = CONFIG  # Alias for clarity
 
 
-@six.python_2_unicode_compatible
 class Preset(object):
     """
     Represents a preset for the web UI for the user to click on
@@ -403,33 +401,33 @@ class RaspiledControlResource(RaspberryPiWebResource):
         """
         Run when user wants to set a colour to a specified value
         """
-        set_colour = request.get_param("set", force=unicode)
+        set_colour = request.args[b"set"][0].decode()
         D("Set to: %s" % set_colour)
         return self.led_strip.set(set_colour)
 
     action__set.capability = {
         "param": "set",
         "description": "Sets the RGB strip to a single colour.",
-        "value": "<unicode> A named colour (e.g. 'pink') or colour hex value (e.g. '#19BECA').",
-        "validity": "<unicode> A known named colour, or valid colour hex in the range #000000-#FFFFFF.",
+        "value": "<str> A named colour (e.g. 'pink') or colour hex value (e.g. '#19BECA').",
+        "validity": "<str> A known named colour, or valid colour hex in the range #000000-#FFFFFF.",
         "widget": "colourpicker",
-        "returns": "<unicode> The hex value of the colour the RGB strip has been set to."
+        "returns": "<str> The hex value of the colour the RGB strip has been set to."
     }
 
     def action__fade(self, request):
         """
         Run when user wants to set a colour to a specified value
         """
-        fade_colour = request.get_param("fade", force=unicode)
+        fade_colour = request.get_param("fade")
         logging.info("Fade to: %s" % fade_colour)
         return self.led_strip.fade(fade_colour)
 
     action__fade.capability = {
         "param": "fade",
         "description": "Fades the RGB strip from its current colour to a specified colour.",
-        "value": "<unicode> A named colour (e.g. 'pink') or colour hex value (e.g. '#19BECA').",
-        "validity": "<unicode> A known named colour, or valid colour hex in the range #000000-#FFFFFF",
-        "returns": "<unicode> The hex value of the colour the RGB strip has been set to."
+        "value": "<str> A named colour (e.g. 'pink') or colour hex value (e.g. '#19BECA').",
+        "validity": "<str> A known named colour, or valid colour hex in the range #000000-#FFFFFF",
+        "returns": "<str> The hex value of the colour the RGB strip has been set to."
     }
 
     def action__sunrise(self, request):
@@ -438,8 +436,8 @@ class RaspiledControlResource(RaspberryPiWebResource):
         """
         seconds = request.get_param(["seconds", "s", "sunrise"], default=10.0, force=float)
         milliseconds = request.get_param(["milliseconds", "ms"], default=0.0, force=float)
-        temp_start = request.get_param(['temp_start', 'K'], default=None, force=unicode)
-        temp_end = request.get_param('temp_end', default=None, force=unicode)
+        temp_start = request.get_param(['temp_start', 'K'], default=None).decode()
+        temp_end = request.get_param('temp_end', default=None).decode()
         logging.info("Sunrise: %s seconds" % (seconds + (milliseconds / 1000.0)))
         return self.led_strip.sunrise(seconds=seconds, milliseconds=milliseconds, temp_start=temp_start, temp_end=temp_end)
 
@@ -458,17 +456,17 @@ class RaspiledControlResource(RaspberryPiWebResource):
             {
                 "param": "temp_start",
                 "value": "The colour temperature you wish to start from (e.g. 500K).",
-                "validity": "<unicode> Matches a named colour temperature (50K - 15000K in 100 Kelvin steps)",
+                "validity": "<str> Matches a named colour temperature (50K - 15000K in 100 Kelvin steps)",
                 "default": "6500K"
             },
             {
                 "param": "temp_end",
                 "value": "The colour temperature you wish to finish at (e.g. 4500K).",
-                "validity": "<unicode> Matches a named colour temperature (50K - 15000K in 100 Kelvin steps)",
+                "validity": "<str> Matches a named colour temperature (50K - 15000K in 100 Kelvin steps)",
                 "default": "500K"
             }
         ],
-        "returns": "<unicode> The hex value of the colour the RGB strip has been set to."
+        "returns": "<str> The hex value of the colour the RGB strip has been set to."
     }
 
     def action__sunset(self, request):
@@ -477,8 +475,8 @@ class RaspiledControlResource(RaspberryPiWebResource):
         """
         seconds = request.get_param(["seconds", "s", "sunset"], default=10.0, force=float)
         milliseconds = request.get_param(["milliseconds", "ms"], default=0.0, force=float)
-        temp_start = request.get_param(['temp_start', 'K'], default=None, force=unicode)
-        temp_end = request.get_param('temp_end', default=None, force=unicode)
+        temp_start = request.get_param(['temp_start', 'K'], default=None).decode()
+        temp_end = request.get_param('temp_end', default=None).decode()
         logging.info("Sunset: %s seconds" % (seconds + (milliseconds / 1000.0)))
         return self.led_strip.sunset(seconds=seconds, milliseconds=milliseconds, temp_start=temp_start, temp_end=temp_end)
 
@@ -497,13 +495,13 @@ class RaspiledControlResource(RaspberryPiWebResource):
             {
                 "param": "temp_start",
                 "value": "The colour temperature you wish to start from (e.g. 500K).",
-                "validity": "<unicode> Matches a named colour temperature (50K - 15000K in 100 Kelvin steps)",
+                "validity": "<str> Matches a named colour temperature (50K - 15000K in 100 Kelvin steps)",
                 "default": "500K"
             },
             {
                 "param": "temp_end",
                 "value": "The colour temperature you wish to finish at (e.g. 4500K).",
-                "validity": "<unicode> Matches a named colour temperature (50K - 15000K in 100 Kelvin steps)",
+                "validity": "<str> Matches a named colour temperature (50K - 15000K in 100 Kelvin steps)",
                 "default": "6500K"
             }
         ],
@@ -526,7 +524,7 @@ class RaspiledControlResource(RaspberryPiWebResource):
         "param": "jump",
         "description": "Hops from one colour to the next over an even period of time.",
         "value": "A comma delimited list of colours you wish to jump between.",
-        "validity": "<unicode> valid colour names or hex values separated by commas (e.g. red,blue,green,cyan,#FF00FF)",
+        "validity": "<str> valid colour names or hex values separated by commas (e.g. red,blue,green,cyan,#FF00FF)",
         "optional_concurrent_parameters": [
             {
                 "param": "milliseconds",
@@ -541,7 +539,7 @@ class RaspiledControlResource(RaspberryPiWebResource):
                 "default": "0",
             },
         ],
-        "returns": "<unicode> The first hex value of sequence."
+        "returns": "<str> The first hex value of sequence."
     }
 
     def action__rotate(self, request):
@@ -560,7 +558,7 @@ class RaspiledControlResource(RaspberryPiWebResource):
         "param": "rotate",
         "description": "Fades from one colour to the next over an even period of time.",
         "value": "A comma delimited list of colours you wish to cross-fade between.",
-        "validity": "<unicode> valid colour names or hex values separated by commas (e.g. red,blue,green,cyan,#FF00FF)",
+        "validity": "<str> valid colour names or hex values separated by commas (e.g. red,blue,green,cyan,#FF00FF)",
         "optional_concurrent_parameters": [
             {
                 "param": "milliseconds",
@@ -575,7 +573,7 @@ class RaspiledControlResource(RaspberryPiWebResource):
                 "default": "0",
             },
         ],
-        "returns": "<unicode> The first hex value of sequence."
+        "returns": "<str> The first hex value of sequence."
     }
 
     def action__stop(self, request):
@@ -588,7 +586,7 @@ class RaspiledControlResource(RaspberryPiWebResource):
         "param": "stop",
         "description": "Halts the current sequence or fade.",
         "value": "",
-        "returns": "<unicode> The hex value of colour the RGB strip got halted on."
+        "returns": "<str> The hex value of colour the RGB strip got halted on."
     }
 
     def action__off(self, request):
@@ -602,7 +600,7 @@ class RaspiledControlResource(RaspberryPiWebResource):
         "param": "off",
         "description": "Stops any fades or sequences. Quickly Fades the RGB strip to black (no light)",
         "value": "",
-        "returns": "<unicode> The hex value of colour the RGB strip ends up at (#000000)."
+        "returns": "<str> The hex value of colour the RGB strip ends up at (#000000)."
     }
 
     def information__status(self, request, *args, **kwargs):
@@ -659,14 +657,17 @@ class SmartRequest(Request, object):
     def __init__(self, *args, **kwargs):
         super(SmartRequest, self).__init__(*args, **kwargs)
 
-    def get_param_values(self, name, default=None):
+    def get_param_values(self, name, default=[]):
         """
         Failsafe way of getting querystring get and post params from the Request object
         If not provided, will return default
         
         @return: ["val1","val2"] LIST of arguments, or the default
         """
-        return self.args.get(name, default)
+        try:
+            return [s.decode() for s in self.args[name.encode()]]
+        except KeyError:
+            return default
 
     get_params = get_param_values  # Alias
     get_list = get_param_values  # Alias
@@ -680,7 +681,7 @@ class SmartRequest(Request, object):
         @keyword default: The default value to return if we cannot get a valid value
         @keyword force: <type> A class / type to force the output into. Default is returned if we cannot force the value into this type 
         """
-        if isinstance(names, (str, unicode)):
+        if not isinstance(names, list):
             names = [names]
         val = NOT_SET
         for name in names:
@@ -713,6 +714,8 @@ class SmartRequest(Request, object):
         Returns True or the value if any of the param names given by args exist
         """
         for param_name in param_names:
+            if isinstance(param_name, str):
+                param_name = param_name.encode()
             try:
                 return self.args[param_name] or True
             except KeyError:
@@ -813,9 +816,9 @@ def start_if_not_running():
     Checks if the process is running, if not, starts it!
     """
     pids = get_matching_pids(APP_NAME, exclude_self=True)  # Will remove own PID
-    pids = filter(bool, pids)
+    pids = list(filter(bool, pids))
     if not pids:  # No match! Implies we need to fire up the listener
-        logging.info("[STARTING] Raspiled Listener with PID %s" % str(os.getpid()))
+        logging.info("[STARTING] Raspiled Listener with PID %s", os.getpid())
         # First the web
         factory = RaspiledControlSite(timeout=8)  # 8s timeout
         try:
@@ -827,7 +830,7 @@ def start_if_not_running():
         # factory.setup_broadcasting(reactor)  # Uncomment to broadcast stuff over network!
         reactor.run()
     else:
-        logging.info("Raspiled Listener already running with PID %s" % ", ".join(pids))
+        logging.info("Raspiled Listener already running with PID %s", ", ".join(pids))
 
 
 if __name__ == "__main__":

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -10,7 +10,7 @@ pigpio==1.78
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.5.2
-scandir==1.7
+scandir==1.10.0
 simplegeneric==0.8.1
 six==1.15.0
 traitlets==4.3.2

--- a/src/utils.py
+++ b/src/utils.py
@@ -3,12 +3,12 @@
 
     A collection of base classes and utilities for the Raspberry Pi powered elements of the Seamless project.
 """
-from __future__ import unicode_literals
 from collections import OrderedDict
 from copy import copy
 import json
 import logging
 import os
+from os import path
 from socket import SOL_SOCKET, SO_BROADCAST
 
 
@@ -16,6 +16,7 @@ from twisted.internet import task
 from twisted.internet.protocol import DatagramProtocol
 from twisted.web.resource import Resource
 from twisted.web.static import File
+
 
 from src.config import DEBUG
 
@@ -87,7 +88,7 @@ class RaspberryPiWebResource(Resource):
         Resource.__init__(self, *args, **kwargs)  # Super
         # Add in the static folder.
         static_folder = os.path.join(RASPBERRY_PI_DIR, self.STATIC_DIRECTORY)
-        self.putChild("static", File(static_folder))  # Any requests to /static serve from the filesystem.
+        self.putChild(b"static", File(static_folder))  # Any requests to /static serve from the filesystem.
 
     def getChild(self, path, request, *args, **kwargs):
         """
@@ -113,14 +114,6 @@ class RaspberryPiWebResource(Resource):
         if path in self.children:
             return self.children[path]
         return self.getChild(path, request)
-
-    @property
-    def clean_path(self):
-        """
-        Provides a clean version of the path
-        :return: <str>
-        """
-        return unicode(self._path or u"").rstrip("/")
 
     def before_action(self, *args, **kwargs):
         """
@@ -265,7 +258,7 @@ class RaspberryPiWebResource(Resource):
         :param request:
         :return: HTML or JSON for serving via Twisted web browser
         """
-        clean_path = unicode(self._path or u"").rstrip("/")
+        clean_path = request.path.rstrip(b"/")
 
         # First see if we're being asked for an informational resource
         for key_name, information_name in self.PARAM_TO_INFORMATION_MAPPING:


### PR DESCRIPTION
Drops references to `unicode`, changes `__unicode__` to `str`, fix
comparisons between `bytes` and `str`.

This brakes Python 2 compatibility.

I started this mainly because Debian 11 comes without Python 2 by default.