### PR TITLE
fix: unescape() and scandir==1.7 when running using python3.9

### DIFF
--- a/src/ledstrip.py
+++ b/src/ledstrip.py
@@ -13,6 +13,7 @@
 from __future__ import unicode_literals
 
 import colorsys
+from html import unescape
 import math
 
 from named_colours import NAMED_COLOURS
@@ -26,7 +27,6 @@ import subprocess
 import time
 from time import sleep
 import threading
-from six.moves.html_parser import HTMLParser
 
 
 ##### Constants #####
@@ -442,10 +442,9 @@ class LEDStrip(object):
         colours.extend(args)
         intermediate_list = []
         # Add in comma delimited stuff
-        h = HTMLParser()
         for colour_term in colours:
             if isinstance(colour_term, (six.text_type, six.binary_type)):
-                colour_term_decoded = h.unescape(colour_term)  # HTML char decode
+                colour_term_decoded = unescape(colour_term)  # HTML char decode
                 colour_terms_list = colour_term_decoded.split(",")
                 intermediate_list.extend(colour_terms_list)
             else:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,7 +11,7 @@ pigpio==1.78
 prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 Pygments==2.5.2
-scandir==1.7
+scandir==1.8
 simplegeneric==0.8.1
 six
 traitlets==4.3.2


### PR DESCRIPTION
# Problem

The latest version of Raspberry Pi OS on Raspberry Pi Zero W is [Debian version: 11 (bullseye)](https://www.raspberrypi.com/software/operating-systems/), which ships with python3.9. The software fails to run on it.

# Fix

1. [ ] The method unescape() is now moved from html.parser to html in [python3.9](https://stackoverflow.com/a/70793745). 
2. [ ] The scandir==1.7 package doesn't build in python3.9. Its updated to 1.8